### PR TITLE
4.0

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,82 @@
+## Help
+The default help system for Concierge.
+
+### Installation
+The easiest way to install is by using `/kpm install help`.
+
+### Usage
+Help provides two Concierge commands:
+- `/help`. This command shows the short version of help for all modules that provide it. As this can grow to have a very long list of commands it will be sent as a private message to the user that sends it (if your platform supports PMs that is).
+- `/help <module name>`. This command shows the long version of help (if provided) for a module.
+
+### Using with your module
+Modules can provide help by one of two approaches. In order of precedence:
+
+#### exports.help(commandPrefix, event) ⇒ <code>array[array[string, string, string?]]</code>
+A module can provide an `exports.help` method. This approach allows for custom logic before returning a help string.
+
+Help returned from this method is represented by an array of arrays. Each inner array contains either two or three strings in the following order:
+1. The command to be executed. E.g. `/example`
+2. A short description of the command.
+3. An optional long description of the command.
+
+**Note**: This method should not be implemented if the `"help"` property has been provided in `kassy.json`. See below.
+**Kind**: API method
+**Returns**: <code>array[array[string, string, string?]]</code>.
+
+| Param | Type | Description |
+| --- | --- | --- |
+| commandPrefix | <code>string</code> | The command prefix associated with the integration that the help was requested on. |
+| event | <code>Object</code> | The event object that caused help to be requested. |
+
+**Example**
+A simple hello world implementation:
+```js
+exports.help = (commandPrefix) => {
+    return [
+        [commandPrefix + 'HelloWorld', 'Prints "Hello World".'],
+        [commandPrefix + 'HelloWorldExtended', 'Prints "Hello World".', 'Prints "Hello World" with extended help.']
+    ];
+}
+```
+
+#### kassy.json#help ⇒ <code>array[array[string, string, string?]]</code>
+A module can provide a `help` property in its `kassy.json`.
+
+**Kind**: Object property
+
+As with the method, this returns help text associated with this module.
+This consists of multiple arrays, each inner array represents one entry in the Concierge help system. Each entry takes the format: `['CommandString/Example', 'ShortDescription', 'OptionalLongDescription']`. As is suggested by the word 'Optional', the last element of this array does not need to be provided (but is highly recommended).
+
+Unlike the method, any string within an entry can contain the special substring `{{commandPrefix}}` which will be replaced with the appropriate string when help is displayed. Additionally, displayed help can also be translated, this is done by using the help strings within `kassy.json` as keys, which then can be looked up within the built in translation service.
+
+**Example**
+A simple hello world implementation:
+```json
+{
+    "help": [
+        ["{{commandPrefix}}helloworld", "Responds with hello world!", "TranslateableLookupKeyHere"]
+    ]
+}
+```
+
+### Middleware
+Help provides middleware such that help output can be intercepted and replaced if desired. This is a template to print the string `Hello middleware` on retreiving the help of each module:
+
+```js
+let helpModule = null;
+
+const helpMiddleware = (mod, commandPrefix, event, next) => {
+    console.log('Hello middleware');
+    return next();
+};
+
+exports.load = platform => {
+    helpModule = platform.getModule('help');
+    helpModule.use('getHelp', helpMiddleware);
+};
+
+exports.unload = () => {
+    helpModule.unuse('getHelp', helpMiddleware);
+};
+```

--- a/help.js
+++ b/help.js
@@ -1,101 +1,71 @@
-const shortSummary = (context, event) => {
-    const modules = exports.platform.modulesLoader.getLoadedModules('module');
-    let help = `${exports.platform.packageInfo.name.toProperCase()} [${exports.platform.packageInfo.version}]\n--------------------\n${exports.platform.packageInfo.homepage}\n\n`;
+const Middleware = require('concierge/middleware');
 
-    for (let i = 0; i < modules.length; i++) {
-        if (!modules[i].help) {
-            continue;
+class HelpModule extends Middleware {
+    _helpForModule(mod, commandPrefix, event) {
+        if (!mod.help && !mod.__descriptor.help) {
+            return null;
         }
-        let cmdHelp = modules[i].ignoreHelpContext
-            ? modules[i].help(context.commandPrefix, event)
-            : modules[i].help.call(context, context.commandPrefix, event);
-        for (let j = 0; j < cmdHelp.length; j++) {
-            help += `→ ${cmdHelp[j][0]}\n\t${cmdHelp[j][1]}\n`;
+
+        if (mod.help) {
+            return mod.help(commandPrefix, event);
         }
-    }
-    return help;
-};
 
-const longDescription = (moduleName, context, event) => {
-    const module = exports.platform.modulesLoader.getLoadedModules('module').find(element => element.__descriptor.name === moduleName);
-
-    if (!module || module.length === 0) {
-        return $$`No help found`;
-    }
-
-    if (module.length > 1) {
-        return $$`Multiple different help results`;
-    }
-
-    let help = '';
-    if (module.help) {
-       const cmdHelp = module.ignoreHelpContext ?
-           module.help(context.commandPrefix, event) :
-           module.help.call(context, context.commandPrefix, event);
-
-       for (let i = 0; i < cmdHelp.length; i++) {
-           const text = cmdHelp[i].length === 3 ? cmdHelp[i][2] : cmdHelp[i][1];
-           help += `${cmdHelp[i][0]}\n--------------------\n${text}\n\n`;
-       }
-    }
-    else {
-       help = $$`Does something. The unhelpful author didn't specify what.`;
-    }
-    return help;
-};
-
-exports.run = (api, event) => {
-    const commands = event.arguments,
-        context = {
-            commandPrefix: api.commandPrefix
-        };
-    let help;
-    if (commands.length === 1) {
-        help = shortSummary(context, event);
-    }
-    else {
-        commands.splice(0, 1);
-        help = longDescription(commands.join(' '), context, event);
-    }
-
-    api.sendPrivateMessage(help, event.thread_id, event.sender_id);
-    return true;
-};
-
-const createHelp = (module) => {
-    if (module.help || ! module.__descriptor.help) {
-        return;
-    }
-
-    module.help = (commandPrefix) => {
-        const h = [],
-            descriptor = module.__descriptor;
-        for (let i = 0; i < descriptor.help.length; i++) {
-            const l = [];
-            for (let j = 0; j < descriptor.help[i].length; j++) {
-                const expression = descriptor.help[i][j].split(/{{commandPrefix}}/g),
+        const name = mod.__descriptor.name,
+            help = mod.__descriptor.help;
+        return help.map(h => {
+            return h.map(s => {
+                const expression = s.split(/{{commandPrefix}}/g),
                     prefixes = Array.from({ length: (expression.length - 1) }, () => commandPrefix);
-                l.push($$.translate(expression, prefixes, descriptor.name));
-            }
-            h.push(l);
-        }
-        return h;
-    };
-};
-
-const loadCallback = (data) => {
-    if (!data.success) return;
-    createHelp(data.module);
-};
-
-exports.load = () => {
-    exports.platform.modulesLoader.on('load', loadCallback);
-    const modules = exports.platform.modulesLoader.getLoadedModules('module');
-    for (let module of modules) {
-        module.help = createHelp(module);
+                return $$.translate(expression, prefixes, name);
+            });
+        });
     }
-};
 
-exports.unload = () => {
-    exports.platform.modulesLoader.removeListener('load', loadCallback);
-};
+    _shortSummary (commandPrefix, event) {
+        const modules = this.platform.modulesLoader.getLoadedModules('module'),
+            help = [`${this.platform.packageInfo.name.toProperCase()} [${this.platform.packageInfo.version}]\n--------------------\n${this.platform.packageInfo.homepage}\n`];
+        for (let mod of modules) {
+            const helpArr = this.runMiddlewareSync('getHelp', this._helpForModule.bind(this), mod, commandPrefix, event);
+            if (!helpArr) {
+                continue;
+            }
+            help.push(helpArr.map(h => `→ ${h[0]}\n\t${h[1]}`));
+        }
+        return help.reduce((a,b)=>a.concat(b),[]).join('\n');
+    }
+
+    _longDescription (moduleName, commandPrefix, event) {
+        const module = this.platform.getModule(moduleName);
+        if (!module || module.length === 0) {
+            return $$`No help found`;
+        }
+
+        if (module.length > 1) {
+            return $$`Multiple different help results`;
+        }
+
+        const help = this.runMiddlewareSync('getHelp', this._helpForModule.bind(this), module, commandPrefix, event);
+        if (help) {
+            return help.map(h => `${h[0]}\n--------------------\n${h[2] || h[1]}`).join('\n\n');
+        }
+        else {
+            return $$`Does something. The unhelpful author didn't specify what.`;
+        }
+    }
+
+    run (api, event) {
+        const commands = event.arguments;
+        let help;
+        if (commands.length === 1) {
+            help = this._shortSummary(api.commandPrefix, event);
+        }
+        else {
+            commands.splice(0, 1);
+            help = this._longDescription(commands.join(' '), api.commandPrefix, event);
+        }
+        api.sendPrivateMessage(help, event.thread_id, event.sender_id);
+        return true;
+    }
+}
+
+module.exports = new HelpModule();

--- a/kassy.json
+++ b/kassy.json
@@ -1,10 +1,10 @@
 {
-	"name": "help",
-	"version": 3.0,
-	"startup": "help.js",
-  "priority": "first",
-  "command":  "help",
-	"help": [
+    "name": "help",
+    "version": 4.0,
+    "startup": "help.js",
+    "priority": "first",
+    "command": "help",
+    "help": [
         ["{{commandPrefix}}help", "Displays this help", "Prints a short summary of all available commands with help"],
         ["{{commandPrefix}}help <query>", "Prints help for a specific module"]
     ]


### PR DESCRIPTION
**Do not merge until https://github.com/concierge/Concierge/pull/241 is merged.**
This depends on the `getModule` api (although it could do the same thing via the longer route, we may as well use the nicer one now that it is possible).

- No need for module load interception
- Reads help directly from `module.__descriptor`
- Provides `getHelp` middleware (sync)
- Some ES6 tidyups
- Readme